### PR TITLE
Better tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "chai": "^3.2.0",
+    "lodash.omit": "^3.1.0",
     "mocha": "^2.3.2",
     "nock": "^2.12.0"
   },

--- a/test/access_token/api.js
+++ b/test/access_token/api.js
@@ -1,0 +1,102 @@
+var nock = require('nock'),
+    expect = require('chai').expect,
+    should = require('chai').should(),
+    FB = require('../..'),
+    omit = require('lodash.omit'),
+    defaultOptions = omit(FB.options(), 'appId');
+
+nock.disableNetConnect();
+
+beforeEach(function () {
+    FB.options(defaultOptions);
+});
+
+afterEach(function () {
+    nock.cleanAll();
+    FB.options(defaultOptions);
+});
+
+describe('access_token', function () {
+
+    describe("FB.setAccessToken('access_token')", function () {
+        it("should set an access_token used by api calls", function (done) {
+            FB.setAccessToken('access_token');
+
+            var expectedRequest = nock('https://graph.facebook.com:443')
+                .get('/me')
+                .query({
+                    access_token: 'access_token',
+                })
+                .reply(200, {
+                    id: "4",
+                    name: "Mark Zuckerberg"
+                });
+
+            FB.api('/me', function (result) {
+                expectedRequest.done();
+                done();
+            });
+
+        });
+    });
+
+    describe("FB.api('/me', { access_token: 'access_token' }, cb)", function () {
+        it('should override an access_token set with FB.setAccessToken()', function (done) {
+            FB.setAccessToken('wrong_token');
+
+            var expectedRequest = nock('https://graph.facebook.com:443')
+                .get('/me')
+                .query({
+                    access_token: 'access_token'
+                })
+                .reply(200, {
+                    id: "4",
+                    name: "Mark Zuckerberg"
+                });
+
+            FB.api('/me', { access_token: 'access_token' }, function (result) {
+                expectedRequest.done();
+                done();
+            });
+        });
+    });
+
+    describe("FB.getAccessToken()", function () {
+        describe("when accessToken is not set", function () {
+            it("should return null", function () {
+                expect(FB.getAccessToken()).to.be.null;
+            });
+        });
+
+        describe("when accessToken is set", function () {
+            it("should return the access_token", function () {
+                FB.setAccessToken('access_token');
+                should.exist(FB.getAccessToken())
+                FB.getAccessToken().should.equal('access_token');
+            });
+        });
+    })
+
+    describe("FB.api('/me', { access_token: 'access_token' }, cb)", function () {
+        it('should include the correct appsecret_proof in the query', function (done) {
+            FB.options({ appSecret: 'app_secret' });
+
+            var expectedRequest = nock('https://graph.facebook.com:443')
+                .get('/me')
+                .query({
+                    access_token: 'access_token',
+                    appsecret_proof: 'd52ddf968d622d8af8677906b7fbae09ac1f89f7cd5c1584b27544624cc23e5a'
+                })
+                .reply(200, {
+                    id: "4",
+                    name: "Mark Zuckerberg"
+                });
+
+            FB.api('/me', { access_token: 'access_token' }, function (result) {
+                expectedRequest.done();
+                done();
+            });
+        });
+    });
+
+});

--- a/test/api/get.js
+++ b/test/api/get.js
@@ -18,9 +18,16 @@ describe('FB.api', function () {
             beforeEach(function () {
                 nock('https://graph.facebook.com:443')
                     .get('/4')
-                    .reply(200, "{\"id\":\"4\",\"name\":\"Mark Zuckerberg\",\"first_name\":\"Mark\",\"last_name\":\"Zuckerberg\",\"link\":\"http:\\/\\/www.facebook.com\\/zuck\",\"username\":\"zuck\",\"gender\":\"male\",\"locale\":\"en_US\"}", { 'access-control-allow-origin': '*',
-                        'content-type': 'text/javascript; charset=UTF-8',
-                        'content-length': '172' });
+                    .reply(200, {
+                        id: "4",
+                        name: "Mark Zuckerberg",
+                        first_name: "Mark",
+                        last_name: "Zuckerberg",
+                        link: "http://www.facebook.com/zuck",
+                        username: "zuck",
+                        gender: "male",
+                        locale: "en_US"
+                    });
             });
 
             it('should have id 4', function (done) {
@@ -43,9 +50,16 @@ describe('FB.api', function () {
             it('should have id 4', function (done) {
                 nock('https://graph.facebook.com:443')
                     .get('/4')
-                    .reply(200, "{\"id\":\"4\",\"name\":\"Mark Zuckerberg\",\"first_name\":\"Mark\",\"last_name\":\"Zuckerberg\",\"link\":\"http:\\/\\/www.facebook.com\\/zuck\",\"username\":\"zuck\",\"gender\":\"male\",\"locale\":\"en_US\"}", { 'access-control-allow-origin': '*',
-                        'content-type': 'text/javascript; charset=UTF-8',
-                        'content-length': '172' });
+                    .reply(200, {
+                        id: "4",
+                        name: "Mark Zuckerberg",
+                        first_name: "Mark",
+                        last_name: "Zuckerberg",
+                        link: "http://www.facebook.com/zuck",
+                        username: "zuck",
+                        gender: "male",
+                        locale: "en_US"
+                    });
 
                 FB.api('/4', function (result) {
                     result.should.have.property('id', '4');
@@ -73,9 +87,9 @@ describe('FB.api', function () {
             it("should return { id: '4' } object", function (done) {
                 nock('https://graph.facebook.com:443')
                     .get('/4?fields=id')
-                    .reply(200, "{\"id\":\"4\"}", {
-                        'content-type': 'text/javascript; charset=UTF-8',
-                        'content-length': '10' });
+                    .reply(200, {
+                        id: "4"
+                    });
 
                 FB.api('4', { fields: 'id'}, function (result) {
                     result.should.include({id: '4'});
@@ -88,9 +102,10 @@ describe('FB.api', function () {
             it("should return { id: '4' } object", function (done) {
                 nock('https://graph.facebook.com:443')
                     .get('/4?fields=name')
-                    .reply(200, "{\"name\":\"Mark Zuckerberg\",\"id\":\"4\"}", {
-                        'content-type': 'text/javascript; charset=UTF-8',
-                        'content-length': '10' });
+                    .reply(200, {
+                        name: "Mark Zuckerberg",
+                        id: "4"
+                    });
 
                 FB.api('4?fields=name', function (result) {
                     result.should.include({id: '4', name: 'Mark Zuckerberg'});
@@ -103,9 +118,10 @@ describe('FB.api', function () {
             it("should return { id: '4', name: 'Mark Zuckerberg' } object", function (done) {
                 nock('https://graph.facebook.com:443')
                     .get('/4?fields=name')
-                    .reply(200, "{\"name\":\"Mark Zuckerberg\",\"id\":\"4\"}", {
-                        'content-type': 'text/javascript; charset=UTF-8',
-                        'content-length': '10' });
+                    .reply(200, {
+                        name: "Mark Zuckerberg",
+                        id: "4"
+                    });
 
                 FB.api('4?fields=name', function (result) {
                     result.should.include({id: '4', name: 'Mark Zuckerberg'});

--- a/test/api/get.js
+++ b/test/api/get.js
@@ -1,13 +1,18 @@
-var nock        = require('nock'),
-    should      = require('chai').should(),
-    FB;
+var nock = require('nock'),
+    should = require('chai').should(),
+    FB = require('../..'),
+    omit = require('lodash.omit'),
+    defaultOptions = omit(FB.options(), 'appId');
+
+nock.disableNetConnect();
 
 beforeEach(function () {
-    FB = require('../..');
+    FB.options(defaultOptions);
 });
 
 afterEach(function () {
-   nock.cleanAll();
+    nock.cleanAll();
+    FB.options(defaultOptions);
 });
 
 describe('FB.api', function () {
@@ -98,22 +103,6 @@ describe('FB.api', function () {
             });
         });
 
-        describe("FB.api('4?fields=name', cb)", function () {
-            it("should return { id: '4' } object", function (done) {
-                nock('https://graph.facebook.com:443')
-                    .get('/4?fields=name')
-                    .reply(200, {
-                        name: "Mark Zuckerberg",
-                        id: "4"
-                    });
-
-                FB.api('4?fields=name', function (result) {
-                    result.should.include({id: '4', name: 'Mark Zuckerberg'});
-                    done();
-                });
-            });
-        });
-
         describe("FB.api('/4?fields=name', cb)", function () {
             it("should return { id: '4', name: 'Mark Zuckerberg' } object", function (done) {
                 nock('https://graph.facebook.com:443')
@@ -123,8 +112,9 @@ describe('FB.api', function () {
                         id: "4"
                     });
 
-                FB.api('4?fields=name', function (result) {
-                    result.should.include({id: '4', name: 'Mark Zuckerberg'});
+                FB.api('/4?fields=name', function (result) {
+                    result.should.have.keys('id', 'name')
+                        .and.include({id: '4', name: 'Mark Zuckerberg'});
                     done();
                 });
             });
@@ -134,6 +124,63 @@ describe('FB.api', function () {
             it("should return { id: '4', name: 'Mark Zuckerberg' } object", function (done) {
                 FB.api('4?fields=name', { fields: 'id,first_name' }, function (result) {
                     result.should.include({id: '4', name: 'Mark Zuckerberg'});
+                    done();
+                });
+            });
+        });
+
+    });
+
+    describe('oauth', function () {
+        describe("FB.api('oauth/access_token', { ..., grant_type: 'client_credentials' }, cb)", function () {
+            it("should return an { access_token: '...' } object", function (done) {
+                nock('https://graph.facebook.com:443')
+                    .get('/oauth/access_token')
+                    .query({
+                        client_id: 'app_id',
+                        client_secret: 'app_secret',
+                        grant_type: 'client_credentials'
+                    })
+                    .reply(200, {
+                        access_token: '...'
+                    });
+
+                FB.api('oauth/access_token', {
+                    client_id: 'app_id',
+                    client_secret: 'app_secret',
+                    grant_type: 'client_credentials'
+                }, function (result) {
+                    result.should.have.keys('access_token')
+                        .and.include({ access_token: '...' });
+                    done();
+                });
+            });
+        });
+    });
+
+});
+
+describe('FB.api', function () {
+    describe('GET', function () {
+
+        describe("FB.napi('/4', cb)", function () {
+            it('should have id 4', function (done) {
+                nock('https://graph.facebook.com:443')
+                    .get('/4')
+                    .reply(200, {
+                        id: "4",
+                        name: "Mark Zuckerberg",
+                        first_name: "Mark",
+                        last_name: "Zuckerberg",
+                        link: "http://www.facebook.com/zuck",
+                        username: "zuck",
+                        gender: "male",
+                        locale: "en_US"
+                    });
+
+                FB.napi('/4', function (err, result) {
+                    should.not.exist(err);
+                    result.should.have.property('id', '4');
                     done();
                 });
             });

--- a/test/login_url/getLoginUrl.js
+++ b/test/login_url/getLoginUrl.js
@@ -1,0 +1,151 @@
+var nock = require('nock'),
+    expect = require('chai').expect,
+    FB = require('../..'),
+    omit = require('lodash.omit'),
+    defaultOptions = omit(FB.options(), 'appId');
+
+nock.disableNetConnect();
+
+beforeEach(function () {
+    FB.options(defaultOptions);
+});
+
+afterEach(function () {
+    nock.cleanAll();
+    FB.options(defaultOptions);
+});
+
+describe("FB.getLoginUrl", function () {
+	var base = 'https://www.facebook.com/dialog/oauth';
+	describe("when no options are set", function () {
+		describe("FB.getLoginUrl({}})", function () {
+			it("should throw", function () {
+				expect(function() { return FB.getLoginUrl({}); }).to.throw;
+			});
+		});
+
+		describe("FB.getLoginUrl({ appId: 'app_id' }})", function () {
+			var url = base + '?response_type=code&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ appId: 'app_id' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id' }})", function () {
+			var url = base + '?response_type=code&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', scope: 'email' }})", function () {
+			var url = base + '?response_type=code&scope=email&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', scope: 'email' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', state: 'state_data' }})", function () {
+			var url = base + '?response_type=code&state=state_data&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', state: 'state_data' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', redirectUri: 'http://example.com/' }})", function () {
+			var url = base + '?response_type=code&redirect_uri=http%3A%2F%2Fexample.com%2F&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', redirectUri: 'http://example.com/' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', redirect_uri: 'http://example.com/' }})", function () {
+			var url = base + '?response_type=code&redirect_uri=http%3A%2F%2Fexample.com%2F&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', redirect_uri: 'http://example.com/' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', display: 'popup' }})", function () {
+			var url = base + '?response_type=code&display=popup&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', display: 'popup' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', responseType: 'token' }})", function () {
+			var url = base + '?response_type=token&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', responseType: 'token' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', response_type: 'token' }})", function () {
+			var url = base + '?response_type=token&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', response_type: 'token' }))
+					.to.equal(url);
+			});
+		});
+	});
+
+	describe("when the redirectUri option is set to http://example.com/", function () {
+		beforeEach(function () {
+			FB.options({redirectUri: 'http://example.com/'})
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id' }})", function () {
+			var url = base + '?response_type=code&redirect_uri=http%3A%2F%2Fexample.com%2F&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', redirectUri: 'http://example.org/' }})", function () {
+			var url = base + '?response_type=code&redirect_uri=http%3A%2F%2Fexample.org%2F&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', redirectUri: 'http://example.org/' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', redirect_uri: 'http://example.org/' }})", function () {
+			var url = base + '?response_type=code&redirect_uri=http%3A%2F%2Fexample.org%2F&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', redirect_uri: 'http://example.org/' }))
+					.to.equal(url);
+			});
+		});
+	});
+
+	describe("when the scope option is set to 'email'", function () {
+		beforeEach(function () {
+			FB.options({scope: 'email'})
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id' }})", function () {
+			var url = base + '?response_type=code&scope=email&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id' }))
+					.to.equal(url);
+			});
+		});
+
+		describe("FB.getLoginUrl({ client_id: 'app_id', scope: 'email,user_likes' }})", function () {
+			var url = base + '?response_type=code&scope=email%2Cuser_likes&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id';
+			it("should equal " + url, function () {
+				expect(FB.getLoginUrl({ client_id: 'app_id', scope: 'email,user_likes' }))
+					.to.equal(url);
+			});
+		});
+	});
+});

--- a/test/options/options.spec.js
+++ b/test/options/options.spec.js
@@ -1,6 +1,19 @@
 var FB = require('../..'),
     nock = require('nock'),
-    should = require('chai').should();
+    should = require('chai').should(),
+    omit = require('lodash.omit'),
+    defaultOptions = omit(FB.options(), 'appId');
+
+nock.disableNetConnect();
+
+beforeEach(function () {
+    FB.options(defaultOptions);
+});
+
+afterEach(function () {
+    nock.cleanAll();
+    FB.options(defaultOptions);
+});
 
 describe('FB.options', function () {
 

--- a/test/signed_request/parseSignedRequest.js
+++ b/test/signed_request/parseSignedRequest.js
@@ -1,0 +1,79 @@
+"use strict";
+var expect = require('chai').expect,
+    FB = require('../..'),
+    omit = require('lodash.omit'),
+    defaultOptions = omit(FB.options(), 'appId'),
+	signature = 'U0_O1MqqNKUt32633zAkdd2Ce-jGVgRgJeRauyx_zC8',
+	app_secret = 'foo_app_secret',
+	payload = 'eyJvYXV0aF90b2tlbiI6ImZvb190b2tlbiIsImFsZ29yaXRobSI6IkhNQUMtU0hBMjU2IiwiaXNzdWVkX2F0IjozMjEsImNvZGUiOiJmb29fY29kZSIsInN0YXRlIjoiZm9vX3N0YXRlIiwidXNlcl9pZCI6MTIzLCJmb28iOiJiYXIifQ==',
+	payloadData = {
+		oauth_token: 'foo_token',
+		algorithm: 'HMAC-SHA256',
+		issued_at: 321,
+		code: 'foo_code',
+		state: 'foo_state',
+		user_id: 123,
+		foo: 'bar'
+	},
+	signedRequest = signature + '.' + payload;
+
+beforeEach(function () {
+    FB.options(defaultOptions);
+});
+
+afterEach(function () {
+    FB.options(defaultOptions);
+});
+
+describe("FB.parseSignedRequest", function () {
+	describe("FB.parseSignedRequest(signedRequest, app_secret)", function () {
+		describe("when app_secret is defined", function () {
+			it("should decode the correct payload", function () {
+				expect(FB.parseSignedRequest(signedRequest, app_secret)).to.exist
+					.and.include(payloadData);
+			});
+
+			it("should prefer the app_secret argument over the appSecret option", function () {
+				FB.options({appSecret: 'wrong_secret'});
+				expect(FB.parseSignedRequest(signedRequest, app_secret)).to.exist
+					.and.include(payloadData);
+			});
+		});
+
+		describe("when signedRequest is undefined", function () {
+			it("should return undefined", function () {
+				expect(FB.parseSignedRequest(undefined, app_secret)).to.be.undefined;
+			});
+		});
+
+		describe("when signedRequest is not two pieces separated by a .", function () {
+			it("should return undefined", function () {
+				expect(FB.parseSignedRequest('wrong', app_secret)).to.be.undefined;
+			});
+		});
+
+		describe("when signedRequest is not base64 encoded", function () {
+			it("should return undefined", function () {
+				expect(FB.parseSignedRequest('wrong.token', app_secret)).to.be.undefined;
+			});
+		});
+
+		describe("when signature is incorrect", function () {
+			it("should return undefined", function () {
+				expect(FB.parseSignedRequest('YmFkc2ln.' + payload, app_secret)).to.be.undefined;
+			});
+		});
+
+		describe("when app_secret is undefined", function () {
+			it("should use the appSecret option to decode the payload", function () {
+				FB.options({appSecret: app_secret});
+				expect(FB.parseSignedRequest(signedRequest)).to.exist
+					.and.include(payloadData);
+			});
+
+			it("should throw when the appSecret option is not defined", function () {
+				expect(function() { return FB.parseSignedRequest(signedRequest) }).to.throw;
+			});
+		});
+	});
+});


### PR DESCRIPTION
- Use JS objects in nock instead of raw JSON strings
- Reset options before and after each test (except appId which would trigger bad http requests)
- Disable the network when nock-ing requests
- Use .have.keys to list an exact list of keys FB.api results should have
- Add oauth request test
- Add FB.napi test
- Cleanup nock in options tests
- Add FB.setAccessToken, FB.getAccessToken, and appsecret_proof tests
- Add FB.parseSignedRequest tests
- Ad FB.getLoginUrl tests