### PR TITLE
Don't use __dirname when requiring package.json.

### DIFF
--- a/fb.js
+++ b/fb.js
@@ -4,7 +4,7 @@
 
         var   request = require('request')
             , crypto  = require('crypto')
-            , version = require(require('path').resolve(__dirname, 'package.json')).version
+            , version = require('./package.json').version
             , getLoginUrl
             , pingFacebook
             , api


### PR DESCRIPTION
This should fix issues with browserifying fb desktop applications.