### PR TITLE
Keys in FB.api params argument should override params in the path arg

### DIFF
--- a/fb.js
+++ b/fb.js
@@ -16,6 +16,7 @@
             rest,
             oauthRequest,
             parseOAuthApiResponse,
+            stringifyParams,
             setAccessToken,
             getAccessToken,
             getAppSecretProof,
@@ -270,51 +271,30 @@
                 uri = 'https://api-read.' + (options('beta') ? 'beta.' : '') + 'facebook.com/' + path;
             }
 
+            parsedUri = URL.parse(uri);
+            delete parsedUri.search;
+            parsedQuery = QS.parse(parsedUri.query);
+
             if(method === 'post') {
-                body = '';
                 if(params.access_token) {
-                    if((uri.indexOf("?") !== -1)) {
-                        uri += '&';
-                    }
-                    else {
-                        uri += '?';
-                    }
-                    uri += 'access_token=' + encodeURIComponent(params.access_token);
-                    delete params['access_token'];
+                    parsedQuery.access_token = params.access_token;
+                    delete params.access_token;
 
                     if(params.appsecret_proof) {
-                        uri += '&appsecret_proof=' + encodeURIComponent(params.appsecret_proof);
-                        delete params['appsecret_proof'];
+                        parsedQuery.appsecret_proof = params.appsecret_proof;
+                        delete params.appsecret_proof;
                     }
                 }
 
-                for(key in params) {
-                    value = params[key];
-                    if(typeof value !== 'string') {
-                        value = JSON.stringify(value);
-                    }
-                    if(value !== undefined) {
-                        body += encodeURIComponent(key) + '=' + encodeURIComponent(value) + '&';
-                    }
-                }
-
-                if(body.length > 0) {
-                    body = body.substring(0, body.length - 1);
-                }
+                body = stringifyParams(params);
             } else {
-                parsedUri = URL.parse(uri);
-                query = QS.parse(parsedUri.query);
                 for(key in params) {
-                    value = params[key];
-                    if(typeof value !== 'string') {
-                        value = JSON.stringify(value);
-                    }
-                    query[key] = value;
+                    parsedQuery[key] = params[key];
                 }
-                delete parsedUri.search;
-                parsedUri.query = query;
-                uri = URL.format(parsedUri);
-            };
+            }
+
+            parsedUri.search = stringifyParams(parsedQuery);
+            uri = URL.format(parsedUri);
 
             pool = { maxSockets: options('maxSockets') || Number(process.env.MAX_SOCKETS) || 5 };
             requestOptions = {
@@ -370,26 +350,34 @@
 
         parseOAuthApiResponse = function(body) {
             var result,
-                key,
-                value,
-                split;
+                key;
 
-            result = {};
-            body = body.split('&');
-            for(var key=0, l=body.length; key<l; key++) {
-                split = body[key].split('=');
-                if(split.length === 2) {
-                    value = split[1];
-                    if(!isNaN(value)) {
-                        result[split[0]] = parseInt(value);
-                    }
-                    else {
-                        result[split[0]] = value;
-                    }
+            result = QS.parse(body);
+            for(key in result) {
+                if(!isNaN(result[key])) {
+                    result[key] = parseInt(result[key]);
                 }
             }
 
             return result;
+        };
+
+        stringifyParams = function(params) {
+            var data = {},
+                key,
+                value;
+
+            for(key in params) {
+                value = params[key];
+                if(value && typeof value !== 'string') {
+                    value = JSON.stringify(value);
+                }
+                if(value !== undefined) {
+                    data[key] = value;
+                }
+            }
+
+            return QS.stringify(data);
         };
 
         log = function(d) {

--- a/fb.js
+++ b/fb.js
@@ -3,6 +3,8 @@
     var FB = (function() {
 
         var request = require('request'),
+            URL     = require('url'),
+            QS      = require('querystring'),
             crypto  = require('crypto'),
             version = require('./package.json').version,
             getLoginUrl,
@@ -232,6 +234,8 @@
          */
         oauthRequest = function(domain, path, method, params, cb) {
             var uri,
+                parsedUri,
+                query,
                 body,
                 key,
                 value,
@@ -298,20 +302,18 @@
                     body = body.substring(0, body.length - 1);
                 }
             } else {
-                if((uri.indexOf("?") !== -1)) {
-                    uri += '&';
-                }
-                else {
-                    uri += '?';
-                }
+                parsedUri = URL.parse(uri);
+                query = QS.parse(parsedUri.query);
                 for(key in params) {
                     value = params[key];
                     if(typeof value !== 'string') {
                         value = JSON.stringify(value);
                     }
-                    uri += encodeURIComponent(key) + '=' + encodeURIComponent(value) + '&';
+                    query[key] = value;
                 }
-                uri = uri.substring(0, uri.length -1);
+                delete parsedUri.search;
+                parsedUri.query = query;
+                uri = URL.format(parsedUri);
             };
 
             pool = { maxSockets: options('maxSockets') || Number(process.env.MAX_SOCKETS) || 5 };

--- a/test/_supports/notError.js
+++ b/test/_supports/notError.js
@@ -1,0 +1,6 @@
+var expect = require('chai').expect;
+
+module.exports = function(result) {
+	expect(result.error && result.error.Error).to.not.exist;
+	expect(result.error).to.not.be.instanceof(Error);
+};

--- a/test/access_token/api.js
+++ b/test/access_token/api.js
@@ -1,6 +1,6 @@
 var nock = require('nock'),
     expect = require('chai').expect,
-    should = require('chai').should(),
+    notError = require('../_supports/notError'),
     FB = require('../..'),
     omit = require('lodash.omit'),
     defaultOptions = omit(FB.options(), 'appId');
@@ -33,6 +33,7 @@ describe('access_token', function() {
                 });
 
             FB.api('/me', function(result) {
+                notError(result);
                 expectedRequest.done();
                 done();
             });
@@ -55,6 +56,7 @@ describe('access_token', function() {
                 });
 
             FB.api('/me', { access_token: 'access_token' }, function(result) {
+                notError(result);
                 expectedRequest.done();
                 done();
             });
@@ -71,8 +73,9 @@ describe('access_token', function() {
         describe("when accessToken is set", function() {
             it("should return the access_token", function() {
                 FB.setAccessToken('access_token');
-                should.exist(FB.getAccessToken())
-                FB.getAccessToken().should.equal('access_token');
+                expect(FB.getAccessToken())
+                    .to.exist
+                    .and.equal('access_token');
             });
         });
     })
@@ -93,6 +96,7 @@ describe('access_token', function() {
                 });
 
             FB.api('/me', { access_token: 'access_token' }, function(result) {
+                notError(result);
                 expectedRequest.done();
                 done();
             });

--- a/test/api/batch.js
+++ b/test/api/batch.js
@@ -1,6 +1,7 @@
 var nock = require('nock'),
-    should = require('chai').should(),
+    expect = require('chai').expect,
     FB = require('../..'),
+    notError = require('../_supports/notError'),
     omit = require('lodash.omit'),
     defaultOptions = omit(FB.options(), 'appId');
 
@@ -77,10 +78,10 @@ describe('FB.api', function() {
                         { method: 'get', relative_url: 'me/friends?limit=50' }
                     ]
                 }, function (result) {
-                    should.not.exist(result.error && result.error.Error);
-                    result.should.be.a('array');
-                    result[0].should.have.property('code', 200);
-                    result[1].should.have.property('code', 200);
+                    notError(result);
+                    expect(result).to.be.a('array');
+                    expect(result[0]).to.have.property('code', 200);
+                    expect(result[1]).to.have.property('code', 200);
                     done();
                 });
             });

--- a/test/api/batch.js
+++ b/test/api/batch.js
@@ -77,6 +77,7 @@ describe('FB.api', function() {
                         { method: 'get', relative_url: 'me/friends?limit=50' }
                     ]
                 }, function (result) {
+                    should.not.exist(result.error && result.error.Error);
                     result.should.be.a('array');
                     result[0].should.have.property('code', 200);
                     result[1].should.have.property('code', 200);

--- a/test/api/fql.js
+++ b/test/api/fql.js
@@ -1,5 +1,6 @@
 var nock = require('nock'),
-    should = require('chai').should(),
+    expect = require('chai').expect,
+    notError = require('../_supports/notError'),
     FB = require('../..'),
     omit = require('lodash.omit'),
     defaultOptions = omit(FB.options(), 'appId');
@@ -30,9 +31,9 @@ describe('FB.api', function() {
                     });
 
                 FB.api('fql', { q: 'SELECT uid FROM user WHERE uid=me()' }, function (res) {
-                    should.not.exist(res.error && res.error.Error);
+                    notError(res);
                     expectedRequest.done();
-                    res.should.have.deep.property('data[0].uid', '4');
+                    expect(res).to.have.deep.property('data[0].uid', '4');
                     done();
                 });
             })
@@ -68,12 +69,12 @@ describe('FB.api', function() {
                     'SELECT uid FROM user WHERE uid=me()',
                     'SELECT name FROM user WHERE uid=me()'
                 ] }, function(res) {
-                    should.not.exist(res.error && res.error.Error);
+                    notError(res);
                     expectedRequest.done();
-                    res.should.have.deep.property('data[0].name', 0);
-                    res.should.have.deep.property('data[1].name', 1);
-                    res.should.have.deep.property('data[0].fql_result_set[0].uid', '4');
-                    res.should.have.deep.property('data[1].fql_result_set[0].name', 'Mark Zuckerberg');
+                    expect(res).to.have.deep.property('data[0].name', 0);
+                    expect(res).to.have.deep.property('data[1].name', 1);
+                    expect(res).to.have.deep.property('data[0].fql_result_set[0].uid', '4');
+                    expect(res).to.have.deep.property('data[1].fql_result_set[0].name', 'Mark Zuckerberg');
                     done();
                 });
             });
@@ -109,12 +110,12 @@ describe('FB.api', function() {
                     id: 'SELECT uid FROM user WHERE uid=me()',
                     name: 'SELECT name FROM user WHERE uid IN (SELECT uid FROM #id)'
                 } }, function(res) {
-                    should.not.exist(res.error && res.error.Error);
+                    notError(res);
                     expectedRequest.done();
-                    res.should.have.deep.property('data[0].name', 'id');
-                    res.should.have.deep.property('data[1].name', 'name');
-                    res.should.have.deep.property('data[0].fql_result_set[0].uid', '4');
-                    res.should.have.deep.property('data[1].fql_result_set[0].name', 'Mark Zuckerberg');
+                    expect(res).to.have.deep.property('data[0].name', 'id');
+                    expect(res).to.have.deep.property('data[1].name', 'name');
+                    expect(res).to.have.deep.property('data[0].fql_result_set[0].uid', '4');
+                    expect(res).to.have.deep.property('data[1].fql_result_set[0].name', 'Mark Zuckerberg');
                     done();
                 });
             });

--- a/test/api/fql.js
+++ b/test/api/fql.js
@@ -30,6 +30,7 @@ describe('FB.api', function() {
                     });
 
                 FB.api('fql', { q: 'SELECT uid FROM user WHERE uid=me()' }, function (res) {
+                    should.not.exist(res.error && res.error.Error);
                     expectedRequest.done();
                     res.should.have.deep.property('data[0].uid', '4');
                     done();
@@ -67,6 +68,7 @@ describe('FB.api', function() {
                     'SELECT uid FROM user WHERE uid=me()',
                     'SELECT name FROM user WHERE uid=me()'
                 ] }, function(res) {
+                    should.not.exist(res.error && res.error.Error);
                     expectedRequest.done();
                     res.should.have.deep.property('data[0].name', 0);
                     res.should.have.deep.property('data[1].name', 1);
@@ -107,6 +109,7 @@ describe('FB.api', function() {
                     id: 'SELECT uid FROM user WHERE uid=me()',
                     name: 'SELECT name FROM user WHERE uid IN (SELECT uid FROM #id)'
                 } }, function(res) {
+                    should.not.exist(res.error && res.error.Error);
                     expectedRequest.done();
                     res.should.have.deep.property('data[0].name', 'id');
                     res.should.have.deep.property('data[1].name', 'name');

--- a/test/api/get.js
+++ b/test/api/get.js
@@ -1,5 +1,6 @@
 var nock = require('nock'),
-    should = require('chai').should(),
+    expect = require('chai').expect,
+    notError = require('../_supports/notError'),
     FB = require('../..'),
     omit = require('lodash.omit'),
     defaultOptions = omit(FB.options(), 'appId');
@@ -35,8 +36,8 @@ describe('FB.api', function() {
 
             it('should have id 4', function(done) {
                 FB.api('4', function(result) {
-                    should.not.exist(result.error && result.error.Error);
-                    result.should.have.property('id', '4');
+                    notError(result);
+                    expect(result).to.have.property('id', '4');
                     done();
                 });
             });
@@ -58,8 +59,8 @@ describe('FB.api', function() {
                     });
 
                 FB.api('/4', function(result) {
-                    should.not.exist(result.error && result.error.Error);
-                    result.should.have.property('id', '4');
+                    notError(result);
+                    expect(result).to.have.property('id', '4');
                     done();
                 });
             });
@@ -89,8 +90,8 @@ describe('FB.api', function() {
                     });
 
                 FB.api('4', { fields: 'id'}, function(result) {
-                    should.not.exist(result.error && result.error.Error);
-                    result.should.include({id: '4'});
+                    notError(result);
+                    expect(result).to.include({id: '4'});
                     done();
                 });
             });
@@ -106,8 +107,8 @@ describe('FB.api', function() {
                     });
 
                 FB.api('/4?fields=name', function(result) {
-                    should.not.exist(result.error && result.error.Error);
-                    result.should.have.keys('id', 'name')
+                    notError(result);
+                    expect(result).to.have.keys('id', 'name')
                         .and.include({id: '4', name: 'Mark Zuckerberg'});
                     done();
                 });
@@ -124,9 +125,9 @@ describe('FB.api', function() {
                     });
 
                 FB.api('4?fields=name', { fields: 'id,name' }, function(result) {
-                    should.not.exist(result.error && result.error.Error);
+                    notError(result);
                     expectedRequest.done();
-                    result.should.include({id: '4', name: 'Mark Zuckerberg'});
+                    expect(result).to.include({id: '4', name: 'Mark Zuckerberg'});
                     done();
                 });
             });
@@ -153,8 +154,8 @@ describe('FB.api', function() {
                     client_secret: 'app_secret',
                     grant_type: 'client_credentials'
                 }, function(result) {
-                    should.not.exist(result.error && result.error.Error);
-                    result.should.have.keys('access_token')
+                    notError(result);
+                    expect(result).to.have.keys('access_token')
                         .and.include({ access_token: '...' });
                     done();
                 });
@@ -183,8 +184,8 @@ describe('FB.api', function() {
                     });
 
                 FB.napi('/4', function(err, result) {
-                    should.not.exist(result.error && result.error.Error);
-                    result.should.have.property('id', '4');
+                    notError(result);
+                    expect(result).to.have.property('id', '4');
                     done();
                 });
             });

--- a/test/api/get.js
+++ b/test/api/get.js
@@ -145,9 +145,7 @@ describe('FB.api', function() {
                         client_secret: 'app_secret',
                         grant_type: 'client_credentials'
                     })
-                    .reply(200, {
-                        access_token: '...'
-                    });
+                    .reply(200, 'access_token=...', {'Content-Type': 'text/plain'});
 
                 FB.api('oauth/access_token', {
                     client_id: 'app_id',
@@ -161,6 +159,34 @@ describe('FB.api', function() {
                 });
             });
         });
+
+        describe("FB.api('oauth/access_token', { grant_type: 'fb_exchange_token', ..., fb_exchange_token: ... }, cb)", function() {
+            it("should return an object with expires as a number", function(done) {
+                nock('https://graph.facebook.com:443')
+                    .get('/v2.0/oauth/access_token')
+                    .query({
+                        grant_type: 'fb_exchange_token',
+                        client_id: 'app_id',
+                        client_secret: 'app_secret',
+                        fb_exchange_token: 'access_token'
+                    })
+                    .reply(200, 'access_token=...&expires=99999', {'Content-Type': 'text/plain'});
+
+                FB.api('oauth/access_token', {
+                    grant_type: 'fb_exchange_token',
+                    client_id: 'app_id',
+                    client_secret: 'app_secret',
+                    fb_exchange_token: 'access_token'
+                }, function(result) {
+                    notError(result);
+                    expect(result).to.have.property('expires')
+                        .and.be.a('number')
+                        .and.equal(99999);
+                    done();
+                });
+            });
+        });
+
     });
 
 });

--- a/test/api/get.js
+++ b/test/api/get.js
@@ -110,9 +110,17 @@ describe('FB.api', function() {
             });
         });
 
-        describe.skip("FB.api('/4?fields=name', { fields: 'id,first_name' }, cb)", function() {
+        describe("FB.api('/4?fields=name', { fields: 'id,first_name' }, cb)", function() {
             it("should return { id: '4', name: 'Mark Zuckerberg' } object", function(done) {
-                FB.api('4?fields=name', { fields: 'id,first_name' }, function(result) {
+                var expectedRequest = nock('https://graph.facebook.com:443')
+                    .get('/v2.0/4?fields=id%2Cname')
+                    .reply(200, {
+                        id: "4",
+                        name: "Mark Zuckerberg"
+                    });
+
+                FB.api('4?fields=name', { fields: 'id,name' }, function(result) {
+                    expectedRequest.done();
                     result.should.include({id: '4', name: 'Mark Zuckerberg'});
                     done();
                 });

--- a/test/api/get.js
+++ b/test/api/get.js
@@ -35,6 +35,7 @@ describe('FB.api', function() {
 
             it('should have id 4', function(done) {
                 FB.api('4', function(result) {
+                    should.not.exist(result.error && result.error.Error);
                     result.should.have.property('id', '4');
                     done();
                 });
@@ -57,6 +58,7 @@ describe('FB.api', function() {
                     });
 
                 FB.api('/4', function(result) {
+                    should.not.exist(result.error && result.error.Error);
                     result.should.have.property('id', '4');
                     done();
                 });
@@ -87,6 +89,7 @@ describe('FB.api', function() {
                     });
 
                 FB.api('4', { fields: 'id'}, function(result) {
+                    should.not.exist(result.error && result.error.Error);
                     result.should.include({id: '4'});
                     done();
                 });
@@ -103,6 +106,7 @@ describe('FB.api', function() {
                     });
 
                 FB.api('/4?fields=name', function(result) {
+                    should.not.exist(result.error && result.error.Error);
                     result.should.have.keys('id', 'name')
                         .and.include({id: '4', name: 'Mark Zuckerberg'});
                     done();
@@ -120,6 +124,7 @@ describe('FB.api', function() {
                     });
 
                 FB.api('4?fields=name', { fields: 'id,name' }, function(result) {
+                    should.not.exist(result.error && result.error.Error);
                     expectedRequest.done();
                     result.should.include({id: '4', name: 'Mark Zuckerberg'});
                     done();
@@ -148,6 +153,7 @@ describe('FB.api', function() {
                     client_secret: 'app_secret',
                     grant_type: 'client_credentials'
                 }, function(result) {
+                    should.not.exist(result.error && result.error.Error);
                     result.should.have.keys('access_token')
                         .and.include({ access_token: '...' });
                     done();
@@ -177,7 +183,7 @@ describe('FB.api', function() {
                     });
 
                 FB.napi('/4', function(err, result) {
-                    should.not.exist(err);
+                    should.not.exist(result.error && result.error.Error);
                     result.should.have.property('id', '4');
                     done();
                 });

--- a/test/api/post.js
+++ b/test/api/post.js
@@ -29,6 +29,7 @@ describe('FB.api', function() {
 
             it('should have id 4_14', function(done) {
                 FB.api('me/feed', 'post', { message: 'My first post using facebook-node-sdk' }, function (result) {
+                    should.not.exist(result.error && result.error.Error);
                     result.should.have.property('id', '4_14');
                     done();
                 });

--- a/test/api/post.js
+++ b/test/api/post.js
@@ -1,5 +1,6 @@
 var nock = require('nock'),
-    should = require('chai').should(),
+    expect = require('chai').expect,
+    notError = require('../_supports/notError'),
     FB = require('../..'),
     omit = require('lodash.omit'),
     defaultOptions = omit(FB.options(), 'appId');
@@ -29,8 +30,8 @@ describe('FB.api', function() {
 
             it('should have id 4_14', function(done) {
                 FB.api('me/feed', 'post', { message: 'My first post using facebook-node-sdk' }, function (result) {
-                    should.not.exist(result.error && result.error.Error);
-                    result.should.have.property('id', '4_14');
+                    notError(result);
+                    expect(result).to.have.property('id', '4_14');
                     done();
                 });
             });

--- a/test/options/options.spec.js
+++ b/test/options/options.spec.js
@@ -33,11 +33,12 @@ describe('FB.options', function() {
         });
 
         it('Should make use graph.facebook when beta is false', function(done) {
-            var expectedRequest = nock('https://graph.facebook.com:443').get('/v2.0/4').reply(200);
+            var expectedRequest = nock('https://graph.facebook.com:443').get('/v2.0/4').reply(200, {});
 
             FB.options({ beta: false });
 
             FB.api('/4', function(result) {
+                should.not.exist(result.error && result.error.Error);
                 expectedRequest.done(); // verify non-beta request was made
 
                 done();
@@ -45,11 +46,12 @@ describe('FB.options', function() {
         });
 
         it('Should make use graph.beta.facebook when beta is true', function(done) {
-            var expectedRequest = nock('https://graph.beta.facebook.com:443').get('/v2.0/4').reply(200);
+            var expectedRequest = nock('https://graph.beta.facebook.com:443').get('/v2.0/4').reply(200, {});
 
             FB.options({ beta: true });
 
             FB.api('/4', function(result) {
+                should.not.exist(result.error && result.error.Error);
                 expectedRequest.done(); // verify beta request was made
 
                 done();
@@ -74,6 +76,7 @@ describe('FB.options', function() {
 
         it("Should default the userAgent for FB.api requests to thuzi_nodejssdk/"+FB.version, function() {
             FB.api('/4', function(result) {
+                should.not.exist(result.error && result.error.Error);
                 result.userAgent.should.equal("thuzi_nodejssdk/"+FB.version);
             });
         });
@@ -82,6 +85,7 @@ describe('FB.options', function() {
             FB.options({userAgent: 'faux/0.0.1'});
 
             FB.api('/4', function(result) {
+                should.not.exist(result.error && result.error.Error);
                 result.userAgent.should.equal('faux/0.0.1');
             });
         });
@@ -108,6 +112,7 @@ describe('FB.options', function() {
                 });
 
             FB.api('4', function(result) {
+                should.not.exist(result.error && result.error.Error);
                 expectedRequest.done();
                 done();
             });
@@ -129,6 +134,7 @@ describe('FB.options', function() {
                 });
 
             FB.api('/v2.3/4', function(result) {
+                should.not.exist(result.error && result.error.Error);
                 expectedRequest.done();
                 done();
             });

--- a/test/options/options.spec.js
+++ b/test/options/options.spec.js
@@ -1,6 +1,7 @@
 var FB = require('../..'),
     nock = require('nock'),
-    should = require('chai').should(),
+    expect = require('chai').expect,
+    notError = require('../_supports/notError'),
     omit = require('lodash.omit'),
     defaultOptions = omit(FB.options(), 'appId');
 
@@ -19,17 +20,17 @@ describe('FB.options', function() {
 
     describe('beta', function() {
         it('Should default beta to false', function() {
-            FB.options('beta').should.be.false;
+            expect(FB.options('beta')).to.be.false;
         });
 
         it('Should allow beta option to be set', function() {
             FB.options({ beta: true });
 
-            FB.options('beta').should.be.true;
+            expect(FB.options('beta')).to.be.true;
 
             FB.options({ beta: false });
 
-            FB.options('beta').should.be.false;
+            expect(FB.options('beta')).to.be.false;
         });
 
         it('Should make use graph.facebook when beta is false', function(done) {
@@ -38,7 +39,7 @@ describe('FB.options', function() {
             FB.options({ beta: false });
 
             FB.api('/4', function(result) {
-                should.not.exist(result.error && result.error.Error);
+                notError(result);
                 expectedRequest.done(); // verify non-beta request was made
 
                 done();
@@ -51,7 +52,7 @@ describe('FB.options', function() {
             FB.options({ beta: true });
 
             FB.api('/4', function(result) {
-                should.not.exist(result.error && result.error.Error);
+                notError(result);
                 expectedRequest.done(); // verify beta request was made
 
                 done();
@@ -71,13 +72,13 @@ describe('FB.options', function() {
         });
 
         it("Should default to thuzi_nodejssdk/"+FB.version, function() {
-            FB.options('userAgent').should.equal("thuzi_nodejssdk/"+FB.version);
+            expect(FB.options('userAgent')).to.equal("thuzi_nodejssdk/"+FB.version);
         });
 
         it("Should default the userAgent for FB.api requests to thuzi_nodejssdk/"+FB.version, function() {
             FB.api('/4', function(result) {
-                should.not.exist(result.error && result.error.Error);
-                result.userAgent.should.equal("thuzi_nodejssdk/"+FB.version);
+                notError(result);
+                expect(result.userAgent).to.equal("thuzi_nodejssdk/"+FB.version);
             });
         });
 
@@ -85,15 +86,15 @@ describe('FB.options', function() {
             FB.options({userAgent: 'faux/0.0.1'});
 
             FB.api('/4', function(result) {
-                should.not.exist(result.error && result.error.Error);
-                result.userAgent.should.equal('faux/0.0.1');
+                notError(result);
+                expect(result.userAgent).to.equal('faux/0.0.1');
             });
         });
     });
 
     describe("version", function() {
         it("Should default version to v2.0", function() {
-            FB.options('version').should.equal('v2.0');
+            expect(FB.options('version')).to.equal('v2.0');
         });
 
         it("Should change the version used in FB.api requests", function(done) {
@@ -112,7 +113,7 @@ describe('FB.options', function() {
                 });
 
             FB.api('4', function(result) {
-                should.not.exist(result.error && result.error.Error);
+                notError(result);
                 expectedRequest.done();
                 done();
             });
@@ -134,7 +135,7 @@ describe('FB.options', function() {
                 });
 
             FB.api('/v2.3/4', function(result) {
-                should.not.exist(result.error && result.error.Error);
+                notError(result);
                 expectedRequest.done();
                 done();
             });
@@ -142,8 +143,8 @@ describe('FB.options', function() {
 
         it("Should change the version used in FB.getLoginUrl", function() {
             FB.options({version: 'v2.4'});
-            FB.getLoginUrl({ appId: 'app_id' })
-                .should.equal('https://www.facebook.com/v2.4/dialog/oauth?response_type=code&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id');
+            expect(FB.getLoginUrl({ appId: 'app_id' }))
+                .to.equal('https://www.facebook.com/v2.4/dialog/oauth?response_type=code&redirect_uri=https%3A%2F%2Fwww.facebook.com%2Fconnect%2Flogin_success.html&client_id=app_id');
         });
     });
 


### PR DESCRIPTION
- Use url and querystring parsing to extract query params from the path.
- Merge these with the params argument.
- Also improve all tests and switch should out with expect.