### PR TITLE
Release 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "fb",
     "graph"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/node-facebook/facebook-node-sdk",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
1.0.0 was published to the `next` tag and cannot be published to the `latest` tag.