### PR TITLE
Add missing variable declaration for parsedQuery to allow use of this library in strict mode

### DIFF
--- a/fb.js
+++ b/fb.js
@@ -237,6 +237,7 @@
         oauthRequest = function(domain, path, method, params, cb) {
             var uri,
                 parsedUri,
+                parsedQuery,
                 query,
                 body,
                 key,


### PR DESCRIPTION
Fixes issue #22 