### PR TITLE
Implement FB.extend and FB.withAccessToken for multi-app and multi-user usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog
     * `nock`: `^2.12.0` -> `^5.2.1`
 * Explicitly support ES2015 `import` in Babel
 * Add `new Facebook(options)` for library usage
+* Add `FB.extend` for multi-app usage
+* Add `FB.withAccessToken` for alternate multi-user usage
 
 ## 1.0.2
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ import {Facebook, FacebookApiException} from 'fb';
 var fb = new Facebook(options);
 ```
 
+## Multi-app usage
+
+Applications that run on behalf of multiple apps with different Facebook appIds and secrets can use `.extend` (on `FB` or any `Facebook` instance) to create a new instance which inherits options not set on it from the instance it is created from (like the API `version` your application is coded against).
+
+```javascript
+FB.options({version: 'v2.4'});
+var fooApp = FB.extend({appId: 'foo_id', appSecret: 'secret'}),
+    barApp = FB.extend({appId: 'bar_id', appSecret: 'secret'});
+```
+
 # Running Samples
 Update `appId` and `appSecret` in `samples/scrumptious/config.js`
 
@@ -451,6 +461,8 @@ FB.api({ method: 'stream.remove', post_id: postId }, function (res) {
 ### setAccessToken
 *This is a non-standard api and does not exist in the official client side FB JS SDK.*
 
+**Warning**: Due to Node's asynchronous nature, you should not use `setAccessToken` when `FB` is used on behalf of for multiple users.
+
 ```js
 FB.setAccessToken('access_token');
 ```
@@ -461,6 +473,15 @@ If you want to use the api compatible with FB JS SDK, pass `access_token` as par
 FB.api('me', { fields: ['id', 'name'], access_token: 'access_token' }, function (res) {
     console.log(res);
 });
+```
+
+### withAccessToken
+*This is a non-standard api and does not exist in the official client side FB JS SDK.*
+
+Using `FB.extend` this returns a new FB object that inherits the same options but has an accessToken specific to it set.
+
+```js
+var fb = FB.withAccessToken('access_token');
 ```
 
 ### getAccessToken

--- a/test/interface/extend.js
+++ b/test/interface/extend.js
@@ -1,0 +1,68 @@
+'use strict';
+import FBdefault, {FB, Facebook} from '../..';
+var expect = require('chai').expect,
+	omit = require('lodash.omit'),
+	defaultOptions = omit(FB.options());
+
+beforeEach(function() {
+	FB.options(defaultOptions);
+});
+
+afterEach(function() {
+	FB.options(defaultOptions);
+});
+
+describe('FB.extend', function() {
+	describe('FB.extend()', function() {
+		it('should create a Facebook instance', function() {
+			var fb = FB.extend();
+			expect(fb).to.be.instanceof(Facebook);
+		});
+
+		it('should not be the same instance as FB', function() {
+			var fb = FB.extend();
+			expect(fb).to.not.equal(FBdefault)
+				.and.to.not.equal(FB);
+		});
+	});
+
+	describe("FB.extend({appId: '42'})", function() {
+		it('should set options passed to it', function() {
+			var fb = FB.extend({appId: '42'});
+			expect(fb.options('appId')).to.equal('42');
+		});
+
+		it('should inherit other options from FB', function() {
+			FB.options({appSecret: 'the_secret'});
+			var fb = FB.extend({appId: '42'});
+			expect(fb.options('appSecret')).to.equal(FB.options('appSecret'));
+		});
+
+		it('should inherit options from FB set after its creation', function() {
+			FB.options({appSecret: 'the_secret'});
+			var fb = FB.extend({appId: '42'});
+			FB.options({appSecret: 'another_secret'});
+			expect(fb.options('appSecret')).to.equal('another_secret');
+		});
+	});
+
+	describe("fb.extend({appId: '42'})", function() {
+		it('should work on an instance made by `new Facebook()` like it does on `FB`', function() {
+			var fb = new Facebook(),
+				fb2 = fb.extend({appId: '42'});
+
+			expect(fb2).to.not.equal(fb);
+			expect(fb.options('appId')).to.not.equal('42');
+			expect(fb2.options('appId')).to.equal('42');
+		});
+	});
+
+	describe("FB.withAccessToken('access_token')", function() {
+		it('should create a new instance with accessToken set', function() {
+			var fb = FB.withAccessToken('access_token');
+			expect(fb).to.not.equal(FB);
+			expect(fb.options('accessToken')).to.equal('access_token');
+			expect(FB.options('accessToken')).to.not.equal(fb.options('accessToken'));
+		});
+	});
+});


### PR DESCRIPTION
- FB.extend creates a new instance that inherits unset options
- FB.withAccessToken uses it to return an instance with its own accessToken
- New README warning for misuse of FB.setAccessToken