### PR TITLE
Separate the lint job done by travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,12 @@ node_js:
   - "4"
   - "0.12"
   - "0.10"
+matrix:
+  env:
+    global:
+      - CI_TEST=no-lint
+  include:
+    - node_js: "5"
+      script: npm run lint
+      env:
+        - CI_TEST=lint-only

--- a/test/lint.js
+++ b/test/lint.js
@@ -1,4 +1,6 @@
 'use strict';
 var lint = require('mocha-eslint');
 
-lint(['.']);
+if ( !process.env.CI_TEST || process.env.CI_TEST !== 'no-lint' ) {
+	lint(['.']);
+}


### PR DESCRIPTION
- Run a separate lint-only job using node@5
- Speed up other jobs by not running the lint tests within mocha unit tests