### PR TITLE
Attemp to not parse non JSON bodies as JSON

### DIFF
--- a/src/fb.js
+++ b/src/fb.js
@@ -384,7 +384,7 @@ class Facebook {
 					response.headers && /.*text\/plain.*/.test(response.headers['content-type'])) {
 					// Parse the querystring body used before v2.3
 					cb(parseOAuthApiResponse(body));
-				} else {
+				} else if (/.*application\/json.*/.test(response.headers['content-type'])) {
 					let json;
 					try {
 						json = JSON.parse(body);
@@ -399,6 +399,14 @@ class Facebook {
 							}
 						};
 					}
+					cb(json);
+				} else {
+					json = {
+						error: { 
+							code 'NOTJSON', 
+							Error: "Received unexpected content-type: " + response.headers['content-type']
+						}
+					};
 					cb(json);
 				}
 			});


### PR DESCRIPTION
It looks like we get JSONPARSE errors not quite infrequently. while we still don't know exactly what happens, its pretty clear the response Content-Type is not application/json, so there's no reason to try to parse it as such.