### PR TITLE
readme instruction install old version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ With facebook-node-sdk you can now easily write the same code and share between 
 # Installing facebook-node-sdk
 
 ```
-npm install fb
+npm install fb@next
 ```
 
 ```javascript


### PR DESCRIPTION
As of today on npm the version is 1.x.x, so running `npm install fb` installs a different version than the one referenced by the examples in the readme