### PR TITLE
Add facebook time function

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,3 +651,18 @@ Step(
     }
 );
 ```
+
+
+## Utils
+
+### now
+
+*This is a non-standard api and does not exist in the official client side FB JS SDK.*
+
+This return the facebook server time as a timestamp.
+
+```js
+FB.now(); //1491494831123
+```
+
+*Please note that as long as you have not made a request to the API the method will return your machine time.*

--- a/src/fb.js
+++ b/src/fb.js
@@ -561,7 +561,6 @@ class Facebook {
      * Please note that as long as you have not made a request to the API the method will return your machine time
      * @access public
      */
-	@autobind
 	now() {
 		return fbTimeDelta+Date.now();
 	}

--- a/src/fb.js
+++ b/src/fb.js
@@ -374,11 +374,6 @@ class Facebook {
 		debugReq(method.toUpperCase() + ' ' + uri);
 		request(requestOptions,
 			(error, response, body) => {
-				let fbTime = Date.parse(response.headers.date);
-				if ( ! isNaN(fbTime) ) {
-					fbTimeDelta = fbTime-Date.now();
-				}
-
 				if ( error !== null ) {
 					if ( error === Object(error) && error::has('error') ) {
 						return cb(error);
@@ -386,7 +381,15 @@ class Facebook {
 					return cb({error});
 				}
 
-				if ( isOAuthRequest && response && response.statusCode === 200 &&
+				if (fbTimeDelta === null && response.headers.date)
+				{
+                    let fbTime = Date.parse(response.headers.date);
+                    if ( ! isNaN(fbTime) ) {
+                        fbTimeDelta = fbTime-Date.now();
+                    }
+				}
+
+                if ( isOAuthRequest && response && response.statusCode === 200 &&
 					response.headers && /.*text\/plain.*/.test(response.headers['content-type'])) {
 					// Parse the querystring body used before v2.3
 					cb(parseOAuthApiResponse(body));

--- a/src/fb.js
+++ b/src/fb.js
@@ -375,7 +375,7 @@ class Facebook {
 		request(requestOptions,
 			(error, response, body) => {
 				let fbTime = Date.parse(response.headers.date);
-				if ( !isNaN(fbTime) ) {
+				if ( ! isNaN(fbTime) ) {
 					fbTimeDelta = fbTime-Date.now();
 				}
 

--- a/src/fb.js
+++ b/src/fb.js
@@ -11,7 +11,7 @@ import FacebookApiException from './FacebookApiException';
 var {version} = require('../package.json'),
 	debugReq = debug('fb:req'),
 	debugSig = debug('fb:sig'),
-    fbTimeDelta = 0,
+	fbTimeDelta = 0,
 	METHODS = ['get', 'post', 'delete', 'put'],
 	toString = Object.prototype.toString,
 	has = Object.prototype.hasOwnProperty,

--- a/src/fb.js
+++ b/src/fb.js
@@ -375,8 +375,8 @@ class Facebook {
 		request(requestOptions,
 			(error, response, body) => {
 				let fbTime = Date.parse(response.headers.date);
-				if (!isNaN(fbTime)) {
-                    fbTimeDelta = fbTime-Date.now();
+				if ( !isNaN(fbTime) ) {
+					fbTimeDelta = fbTime-Date.now();
 				}
 
 				if ( error !== null ) {
@@ -562,7 +562,7 @@ class Facebook {
      * @access public
      */
 	now() {
-		return fbTimeDelta+Date.now();
+		return fbTimeDelta + Date.now();
 	}
 
 	/**

--- a/src/fb.js
+++ b/src/fb.js
@@ -381,7 +381,7 @@ class Facebook {
 					return cb({error});
 				}
 
-				if (fbTimeDelta === null && response.headers.date) {
+				if (fbTimeDelta === null && response && response.headers.date) {
                     let fbTime = Date.parse(response.headers.date);
                     if ( ! isNaN(fbTime) ) {
                         fbTimeDelta = fbTime-Date.now();

--- a/src/fb.js
+++ b/src/fb.js
@@ -11,6 +11,7 @@ import FacebookApiException from './FacebookApiException';
 var {version} = require('../package.json'),
 	debugReq = debug('fb:req'),
 	debugSig = debug('fb:sig'),
+    fbTimeDelta = 0,
 	METHODS = ['get', 'post', 'delete', 'put'],
 	toString = Object.prototype.toString,
 	has = Object.prototype.hasOwnProperty,
@@ -373,6 +374,11 @@ class Facebook {
 		debugReq(method.toUpperCase() + ' ' + uri);
 		request(requestOptions,
 			(error, response, body) => {
+				let fbTime = Date.parse(response.headers.date);
+				if (!isNaN(fbTime)) {
+                    fbTimeDelta = fbTime-Date.now();
+				}
+
 				if ( error !== null ) {
 					if ( error === Object(error) && error::has('error') ) {
 						return cb(error);
@@ -548,6 +554,16 @@ class Facebook {
 				}
 			}
 		}
+	}
+
+    /**
+     * Return the facebook server time as a timestamp
+     * Please note that as long as you have not made a request to the API the method will return your machine time
+     * @access public
+     */
+	@autobind
+	now() {
+		return fbTimeDelta+Date.now();
 	}
 
 	/**

--- a/src/fb.js
+++ b/src/fb.js
@@ -381,8 +381,7 @@ class Facebook {
 					return cb({error});
 				}
 
-				if (fbTimeDelta === null && response.headers.date)
-				{
+				if (fbTimeDelta === null && response.headers.date) {
                     let fbTime = Date.parse(response.headers.date);
                     if ( ! isNaN(fbTime) ) {
                         fbTimeDelta = fbTime-Date.now();


### PR DESCRIPTION
Hi,

this add a function to get the current facebook time. It's based on the date returned by facebook in the http headers of a request response. The delta is calculated against the current time machine.