### PR TITLE
allow passing request wrapper option

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ var accessToken = FB.options('accessToken'); //will get the accessToken of 'XYZ'
 ```
 
 The existing options are:
+* `'request'` [request](https://github.com/request/requests) function that will be used to make API requests. Allows the configuration of request [options](https://github.com/request/request#requestoptions-callback) by passing the result of calling [`request.defaults`](https://github.com/request/request#requestdefaultsoptions).
 * `'accessToken'` string representing the Facebook accessToken to be used for requests. This is the same option that is updated by the `setAccessToken` and `getAccessToken` methods.
 * `'appId'` The ID of your app, found in your app's dashboard.
 * `'appSecret'` string representing the Facebook application secret.

--- a/src/fb.js
+++ b/src/fb.js
@@ -19,6 +19,7 @@ var {version} = require('../package.json'),
 		console.log(d); // eslint-disable-line no-console
 	},
 	defaultOptions = Object.assign(Object.create(null), {
+		request,
 		Promise: Promise,
 		accessToken: null,
 		appId: null,
@@ -386,7 +387,7 @@ class Facebook {
 		}
 
 		debugReq(method.toUpperCase() + ' ' + uri);
-		request(requestOptions,
+		this.options('request')(requestOptions,
 			(error, response, body) => {
 				if ( error !== null ) {
 					if ( error === Object(error) && error::has('error') ) {

--- a/test/options/options.spec.js
+++ b/test/options/options.spec.js
@@ -5,6 +5,7 @@ var FB = require('../..'),
 	notError = require('../_supports/notError'),
 	omit = require('lodash.omit'),
 	defaultOptions = omit(FB.options(), 'appId'),
+	request = require('request'),
 	{version} = require('../../package.json');
 
 nock.disableNetConnect();
@@ -19,6 +20,19 @@ afterEach(function() {
 });
 
 describe('FB.options', function() {
+	describe('request', function() {
+		it('Should default to request', function() {
+			expect(FB.options('request')).to.equal(request);
+		});
+
+		it('Should allow request to be set', function() {
+			const wrapped = request.defaults();
+			FB.options({request: wrapped});
+			expect(FB.options('request')).to.equal(wrapped);
+			expect(FB.options('request')).to.not.equal(request);
+		});
+	});
+
 	describe('beta', function() {
 		it('Should default beta to false', function() {
 			expect(FB.options('beta')).to.be.false;


### PR DESCRIPTION
request has a robust set of options that are currently inaccessible. This PR allows FB users to supply their own request wrapper, so that all request options are configurable.

allows #100 to be addressed by library users by supplying their own agent

