### PR TITLE
change http client from request to needle

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,8 @@ var accessToken = FB.options('accessToken'); //will get the accessToken of 'XYZ'
 ```
 
 The existing options are:
+* `'onRequest'` function called with the [`http.ClientRequest`](https://nodejs.org/api/http.html#http_class_http_clientrequest) for each request.
+* `'requestOptions'` Object of [needle request options](https://github.com/tomas/needle#request-options) to apply to all http requests. The following FB options take priority over requestOptions: `proxy`, `timeout`, `userAgent`.
 * `'accessToken'` string representing the Facebook accessToken to be used for requests. This is the same option that is updated by the `setAccessToken` and `getAccessToken` methods.
 * `'appId'` The ID of your app, found in your app's dashboard.
 * `'appSecret'` string representing the Facebook application secret.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "babel-runtime": "^6.23.0",
     "core-decorators": "^0.17.0",
     "debug": "^2.6.3",
-    "request": "^2.81.0"
+    "form-data": "^2.3.1",
+    "lodash.defaultsdeep": "^4.6.0",
+    "needle": "^2.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/test/options/options.spec.js
+++ b/test/options/options.spec.js
@@ -19,6 +19,49 @@ afterEach(function() {
 });
 
 describe('FB.options', function() {
+	describe('onRequest', function() {
+		it('Should be called with the request object', function(done) {
+			const expectedRequest = nock('https://graph.facebook.com:443').get('/v2.3/4').reply(200, {});
+			let called = false;
+			let nockRequest;
+			expectedRequest.on('request', request => { nockRequest = request; });
+			FB.options({
+				onRequest(request) {
+					called = true;
+					expect(request).to.equal(nockRequest);
+				}
+			});
+			FB.api('/4', function(result) {
+				notError(result);
+				expectedRequest.done();
+				expect(called).to.be.true;
+				done();
+			});
+		});
+	});
+
+	describe('requestOptions', function() {
+		it('Should be deep defaults for per-request options', function(done) {
+			const headers = {'X-Test-Header': 'test'};
+			const expectedRequest = nock(
+				'https://graph.facebook.com:443',
+				{
+					reqheaders: headers
+				}
+			).get('/v2.3/4').reply(200, {});
+			FB.options({
+				requestOptions: {
+					headers
+				}
+			});
+			FB.api('/4', function(result) {
+				notError(result);
+				expectedRequest.done();
+				done();
+			});
+		});
+	});
+
 	describe('beta', function() {
 		it('Should default beta to false', function() {
 			expect(FB.options('beta')).to.be.false;


### PR DESCRIPTION
- postParamData handles the construction of a FormData instance when
  the request body is required to be multipart. This maintains the
  existing contract for file uploads.
- added FB option onRequest to allow callers to hook the
  http.ClientRequest when a request is generated.
- added FB option requestOptions, which are applied to all requests