### PR TITLE
Add a warning when `fields` is passed an array instead of a comma separated string

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
     "object-curly-spacing": [1, "never"],
     "prefer-arrow-callback": [1],
     "quote-props": [2, "as-needed"],
-    "quotes": [1, "single", "avoid-escape"],
+    "quotes": [1, "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
     "semi": [2, "always"],
     "spaced-comment": [2, "always"],
     "keyword-spacing": [1, {"before": true, "after": true}],

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "lodash.omit": "^4.5.0",
     "mocha": "^3.2.0",
     "mocha-eslint": "^3.0.1",
-    "nock": "^9.2.1"
+    "nock": "^9.2.1",
+    "sinon": "^4.4.2",
+    "sinon-chai": "^2.14.0"
   },
   "engines": {
     "node": ">=4"

--- a/src/fb.js
+++ b/src/fb.js
@@ -17,7 +17,7 @@ var {version} = require('../package.json'),
 	has = Object.prototype.hasOwnProperty,
 	log = function(d) {
 		// todo
-		console.log(d); // eslint-disable-line no-console
+		console.warn(d); // eslint-disable-line no-console
 	},
 	defaultOptions = Object.assign(Object.create(null), {
 		Promise: Promise,
@@ -62,6 +62,12 @@ var {version} = require('../package.json'),
 	},
 	stringifyParams = function(params) {
 		var data = {};
+
+		// https://developers.facebook.com/bugs/1925316137705574/
+		// fields=[] as json is not officialy supported, however the README has made people mistakenly do so
+		if ( Array.isArray(params.fields) ) {
+			log(`The fields param should be a comma separated list, not an array, try changing it to: ${JSON.stringify(params.fields)}.join(',')`);
+		}
 
 		for ( let key in params ) {
 			let value = params[key];

--- a/test_live/_supports/chai.js
+++ b/test_live/_supports/chai.js
@@ -1,8 +1,10 @@
 'use strict';
 import chai, {expect} from 'chai';
 import cap from 'chai-as-promised';
+import sinon from 'sinon-chai';
 
 chai.use(cap);
+chai.use(sinon);
 
 export default chai;
 export {expect};

--- a/test_live/basic/error.js
+++ b/test_live/basic/error.js
@@ -1,6 +1,7 @@
 'use strict';
 import {expect} from '../_supports/chai';
 import FB, {FacebookApiException} from '../_supports/fb';
+import sinon from 'sinon';
 
 describe('error', function() {
 	describe("FB.api('/404')", function() {
@@ -12,6 +13,23 @@ describe('error', function() {
 					.that.is.a('object')
 					.with.property('error')
 						.that.has.keys(['message', 'type', 'code', 'error_subcode', 'fbtrace_id']);
+		});
+	});
+
+	describe("FB.api('/me', {fields: ['id', 'name']})", function() {
+		beforeEach(function() {
+			sinon.spy(console, 'warn');
+		});
+
+		afterEach(function() {
+			console.warn.restore(); // eslint-disable-line no-console
+		});
+
+		it('should emit a warning when fields is an array', async function() {
+			await FB.api('/me', {fields: ['id', 'name']});
+			expect(console.warn).to.have.been.calledWith( // eslint-disable-line no-console
+				`The fields param should be a comma separated list, not an array, try changing it to: ["id","name"].join(',')`
+			);
 		});
 	});
 });


### PR DESCRIPTION
Also change console.log to console.warn to avoid polluting stdout