### PR TITLE
Throw a TypeError when passing bad arguments to FB.api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 * Debug headers are now logged with DEBUG=fb:fbdebug
 * Log messages to stderr using console.warn instead of console.log
 * **BREAKING CHANGE**: Switched from the `request` library to `needle`
+* **BREAKING CHANGE**: Passing invalid methods or arguments to `FB.api` now throws a TypeError instead of logging and returning undefined
 
 ## 2.0.0
 

--- a/src/fb.js
+++ b/src/fb.js
@@ -307,8 +307,7 @@ class Facebook {
 			} else if ( type === 'object' && !params ) {
 				params = next;
 			} else {
-				log('Invalid argument passed to FB.api(): ' + next);
-				return;
+				throw new TypeError('Invalid argument passed to FB.api(): ' + next);
 			}
 			next = args.shift();
 		}
@@ -322,8 +321,7 @@ class Facebook {
 		}
 
 		if ( METHODS.indexOf(method) < 0 ) {
-			log('Invalid method passed to FB.api(): ' + method);
-			return;
+			throw new TypeError('Invalid method passed to FB.api(): ' + method);
 		}
 
 		this[oauthRequest](path, method, params, cb);


### PR DESCRIPTION
Instead of logging to the console and returning undefined.