### PR TITLE
Require node 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [["env", {"targets": {"node": 4}}], "stage-0"],
+  "presets": [["env", {"targets": {"node": 6}}], "stage-0"],
   "plugins": ["transform-decorators-legacy", "transform-runtime"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "9"
   - "8"
   - "6"
-  - "4"
 env:
   global:
     - CI_TEST=no-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 * **BREAKING CHANGE**: Passing invalid methods or arguments to `FB.api` now throws a TypeError instead of logging and returning undefined
 * Use of the [function-bind operator](https://github.com/tc39/proposal-bind-operator) has been removed
 * **BREAKING CHANGE**: Raised the minimum supported version of Node to `6.x`
+* **BREAKING CHANGE**: `any-promise` has been removed, native promises are now returned by default. If you wish to use a 3rd party promise library like `bluebird` you must explicitly set the `Promise` option instead of relying on `any-promise`'s behaviour
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 * **BREAKING CHANGE**: Switched from the `request` library to `needle`
 * **BREAKING CHANGE**: Passing invalid methods or arguments to `FB.api` now throws a TypeError instead of logging and returning undefined
 * Use of the [function-bind operator](https://github.com/tc39/proposal-bind-operator) has been removed
+* **BREAKING CHANGE**: Raised the minimum supported version of Node to `6.x`
 
 ## 2.0.0
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "any-promise": "^1.3.0",
     "babel-runtime": "^6.23.0",
     "core-decorators": "^0.17.0",
     "debug": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sinon-chai": "^2.14.0"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "lint-staged": {
     "*.js": [

--- a/src/fb.js
+++ b/src/fb.js
@@ -1,5 +1,4 @@
 'use strict';
-import Promise from 'any-promise';
 import {autobind} from 'core-decorators';
 import debug from 'debug';
 import FormData from 'form-data';

--- a/test/api/get.js
+++ b/test/api/get.js
@@ -308,33 +308,6 @@ describe('FB.api', function() {
 
 				expect(ret).to.have.property('then').that.is.a('function');
 				expect(ret).to.have.property('catch').that.is.a('function');
-				expect(ret).to.be.an.instanceof(require('any-promise'));
-				ret
-					.then((result) => {
-						expect(result).to.have.property('id', '4');
-						done();
-					});
-			});
-
-			it('should work when the Promise option is native Promise', function(done) {
-				nock('https://graph.facebook.com:443')
-					.get('/v2.5/4')
-					.reply(200, {
-						id: '4',
-						name: 'Mark Zuckerberg',
-						first_name: 'Mark',
-						last_name: 'Zuckerberg',
-						link: 'http://www.facebook.com/zuck',
-						username: 'zuck',
-						gender: 'male',
-						locale: 'en_US'
-					});
-
-				var fb = new FB.Facebook({Promise: Promise});
-				var ret = fb.api('/4');
-
-				expect(ret).to.have.property('then').that.is.a('function');
-				expect(ret).to.have.property('catch').that.is.a('function');
 				expect(ret).to.be.an.instanceof(Promise);
 				ret
 					.then((result) => {

--- a/test/interface/import.js
+++ b/test/interface/import.js
@@ -62,7 +62,7 @@ describe('import', function() {
 	});
 
 	describe("import {FacebookApiException} from 'fb';", function() {
-		it('should expose the FacebookApiException eror typei', function() {
+		it('should expose the FacebookApiException error type', function() {
 			expect(FacebookApiExceptionImport).to.equal(FacebookApiException);
 		});
 	});

--- a/test/interface/misc.js
+++ b/test/interface/misc.js
@@ -11,7 +11,7 @@ describe('FB.FacebookApiException', function() {
 			.and.to.be.a('function');
 	});
 
-	it('should create a FacebookApiExceptionn instance that derives from Error', function() {
+	it('should create a FacebookApiException instance that derives from Error', function() {
 		var obj = {};
 		expect(new FB.FacebookApiException(obj))
 			.to.be.an.instanceof(FacebookApiException)


### PR DESCRIPTION
- Node 6.x is the new minimum
- `any-promise` has been removed and FB will now return native Promises by default