### PR TITLE
Remove function bind and throw TypeErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog
 * Debug headers are now logged with DEBUG=fb:fbdebug
 * Log messages to stderr using console.warn instead of console.log
 * **BREAKING CHANGE**: Switched from the `request` library to `needle`
+* **BREAKING CHANGE**: Passing invalid methods or arguments to `FB.api` now throws a TypeError instead of logging and returning undefined
+* Use of the [function-bind operator](https://github.com/tc39/proposal-bind-operator) has been removed
 
 ## 2.0.0
 


### PR DESCRIPTION
- Throw a TypeError when passing bad arguments to FB.api
  Instead of logging to the console and returning undefined.
- Also remove usage of the function-bind operator

I accidentally mixed up the commits for these before, so I'm just going to commit these together.